### PR TITLE
BUGFIX parsing of "this quarter of an hour"

### DIFF
--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -953,9 +953,9 @@ def extract_datetime_en(string, dateNow, default_time):
             elif wordPrevPrev == "quarter":
                 minOffset = 15
                 if idx > 2 and words[idx - 3] in markers:
-                    words[idx - 3] = ""
                     if words[idx - 3] == "this":
                         daySpecified = True
+                    words[idx - 3] = ""
                 words[idx - 2] = ""
             elif wordPrev == "within":
                 hrOffset = 1


### PR DESCRIPTION
The test for "this" was checking after the word slot had already been wiped out.