### PR TITLE
fix: circular import in main modules

### DIFF
--- a/lingua_nostra/format.py
+++ b/lingua_nostra/format.py
@@ -39,9 +39,6 @@ _REGISTERED_FUNCTIONS = ("nice_number",
                          "nice_response",
                          "nice_duration")
 
-populate_localized_function_dict("format", langs=get_active_langs())
-
-
 @localized_function(run_own_code_on=[FunctionNotLocalizedError])
 def nice_units(utterance=None, lang=''):
     """  Format a unit to a pronouncable string
@@ -746,3 +743,5 @@ def nice_bytes(number, lang='', speech=True, binary=True, gnu=False):
             return "%3.1f %s" % (number, unit)
         number /= n
     return "%.1f %s" % (number, units[-1])
+
+populate_localized_function_dict("format", langs=get_active_langs())

--- a/lingua_nostra/parse.py
+++ b/lingua_nostra/parse.py
@@ -34,8 +34,6 @@ _REGISTERED_FUNCTIONS = ("extract_numbers",
                          "is_fractional",
                          "is_ordinal")
 
-populate_localized_function_dict("parse", langs=get_active_langs())
-
 
 @localized_function(run_own_code_on=[FunctionNotLocalizedError])
 def normalize_decimals(text, decimal, lang=""):
@@ -369,3 +367,5 @@ def is_ordinal(input_str, lang=''):
         (bool) or (float): False if not an ordinal, otherwise the number
         corresponding to the ordinal
     """
+
+populate_localized_function_dict("parse", langs=get_active_langs())

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("readme.md", "r") as fh:
 
 setup(
     name='lingua_nostra',
-    version='0.4.5',
+    version='0.4.6',
     packages=['lingua_nostra', 'lingua_nostra.lang'],
     url='https://github.com/HelloChatterbox/lingua-nostra',
     license='Apache2.0',


### PR DESCRIPTION
Attempting to populate the localized function dictionary at the top, when language modules are already loaded, results in a circular import. The localized modules attempt to refer back to their parents during the import-and-crawl phrase.

Populating the dictionaries at the bottom of the files doesn't break any tests, but it does stop the error.